### PR TITLE
One potential fix for Issue #5 is this pull request.

### DIFF
--- a/api_mapping.json
+++ b/api_mapping.json
@@ -1,0 +1,87 @@
+{
+  "apis": [
+    {
+      "api_name": "default",
+      "url": "http://api.weatherapi.com/v1/current.json",
+      "pre_key": "?key=2f52d9bd7df943bfa5c110209242903",
+      "location_prefix": "&q=",
+      "post_key": "",
+      "data": [
+        {
+          "description": "temp",
+          "path": ["current", "temp_c"]
+        },
+        {
+          "description": "temp_f",
+          "path": ["current", "temp_f"]
+        },
+        {
+          "description": "wind_mph",
+          "path": ["current", "wind_mph"]
+        },
+        {
+          "description": "wind_kph",
+          "path": ["current", "wind_kph"]
+        },
+        {
+          "description": "humidity",
+          "path": ["current", "humidity"]
+        },
+        {
+          "description": "cloudcover",
+          "path": ["current", "cloud"]
+        }
+      ]
+    },
+    {
+      "api_name": "visualcrossing.com",
+      "url": "https://weather.visualcrossing.com/VisualCrossingWebServices/rest/services/timeline/",
+      "pre_key": "",
+      "location_prefix": "/",
+      "post_key": "?key=63HXSPFMH4H4PM4XAPVXVJU62",
+      "data": [
+        {
+          "description": "temp",
+          "path": ["currentConditions", "temp"]
+        },
+        {
+          "description": "wind_kph",
+          "path": ["currentConditions", "windspeed"]
+        },
+        {
+          "description": "humidity",
+          "path": ["currentConditions", "humidity"]
+        },
+        {
+          "description": "cloudcover",
+          "path": ["currentConditions", "cloudcover"]
+        }
+      ]
+    },
+    {
+      "api_name": "weatherstack.com",
+      "url": "http://api.weatherstack.com/current",
+      "pre_key": "?access_key=3642789fb73139385cad4d314ddea158",
+      "location_prefix": "&query=",
+      "post_key": "",
+      "data": [
+        {
+          "description": "temp",
+          "path": ["current", "temperature"]
+        },
+        {
+          "description": "wind_kph",
+          "path": ["current", "wind_speed"]
+        },
+        {
+          "description": "humidity",
+          "path": ["current", "humidity"]
+        },
+        {
+          "description": "cloudcover",
+          "path": ["current", "cloudcover"]
+        }
+      ]
+    }
+  ]
+}

--- a/api_mapping.py
+++ b/api_mapping.py
@@ -1,0 +1,113 @@
+import json
+
+class FieldClass:
+    field_name: str
+    keys: [str]
+    def __init__(self, field_name: str, keys:[str]):
+        self.field_name= field_name
+        self.keys = keys
+
+class ApiMapping():
+    """
+    Class encompassing all methods for the mapping and field map for any api defined in the api_mapping.json file.
+    """
+    fields = ['temp', 'temp_f', 'wind_mph', 'wind_kph', 'humidity', 'cloudcover']
+    api_mapping : dict
+    file_input : str
+    field_mapping : [FieldClass]
+
+    def __init__(self, file_input):
+        self.file_input = file_input
+
+    def load_mapping(self):
+        """
+        loads the mapping file defined in teh file_input attribute of the class
+        :return:
+        """
+        with open(self.file_input, 'r') as file:
+            data = json.load(file)
+        self.api_mapping = data
+
+    def get_formed_url(self, api: str, city: str):
+        """
+        Builds a full formed http/https get request for a given API
+        :param api:  API name to find in the mapping file
+        :param city: City name or code for API request
+        :return:  A fully formed request string
+        """
+        formed_url = None
+        api_connection_fields = self.api_mapping['apis']
+        for fields in api_connection_fields:
+            if fields["api_name"] == api:
+                url = fields["url"]
+                pre_key = fields["pre_key"]
+                location_prefix = fields["location_prefix"]
+                post_key = fields["post_key"]
+                formed_url = f"{url}{pre_key}{location_prefix}{city}{post_key}"
+        return formed_url
+
+    def load_fields(self, api: str):
+        """
+        Sotes a field mapping into the class' field_mapping attribute for a given API name
+        :param api:  Name of the api to retrieve the field map
+        :return: None
+        """
+        field_mapping = []
+        for apis in self.api_mapping["apis"]:
+            if apis["api_name"] == api:
+                for field in apis["data"]:
+                    field_description = field["description"]
+                    keys = []
+                    for key in field["path"]:
+                        keys.append(key)
+                    complete_field_map = FieldClass(field_description, keys)
+                    field_mapping.append(complete_field_map)
+        self.field_mapping = field_mapping
+
+    def parse_fields(self, api_json: json):
+        """
+        Parses the fields defined in the class fields attribute
+        Adds missing fields via calculation helper methods if required
+        :param api_json:  json stream of response object of API call
+        :return:  dictionary of values from the response json
+        """
+        output = {}
+        for field in self.fields:
+            field_map = self.field_mapping
+            for fm in field_map:
+                if (fm.field_name == field):
+                    key_list = fm.keys
+                    try:
+                        value = api_json
+                        for key in key_list:
+                            value = value[key]
+                            print("value : " + str(value))
+                            output[field] = value
+                    except:
+                        pass
+        #cabeats for converting from metric
+        if output.get("temp_f") is None:
+            print(" output get temp : " + str(output.get("temp")))
+            temp_f = self.c_to_f_degrees(output.get("temp"))
+            output["temp_f"] = temp_f
+        if output.get("wind_mph") is None:
+            print(" output get temp : " + str(output.get("wind_kph")))
+            wind_mph = self.kph_to_mph(output.get("wind_kph"))
+            output["wind_mph"] = wind_mph
+        return output
+
+    def kph_to_mph(self, kph: float):
+        """
+        Convert kilometers per hour to miles per hour
+        :param kph: kilometers per hour
+        :return: miles per hour
+        """
+        return kph * (0.621371)
+
+    def c_to_f_degrees(self, celsius: float):
+        """
+        Convert celsius to fahrenheit
+        :param celsius: value in celsius
+        :return: fahrenheit value
+        """
+        return ((celsius * 1.8) + 32)

--- a/weather2.py
+++ b/weather2.py
@@ -1,38 +1,46 @@
 import requests
 import json
 import os
+from api_mapping import ApiMapping
 
-def weather_info(city, x):
-    url = f"http://api.weatherapi.com/v1/current.json?key=2f52d9bd7df943bfa5c110209242903&q={city}"
-    r = requests.get(url)
-    wdic = json.loads(r.text)
+def weather_info(city, x, a):
+    api_mapping_file = 'api_mapping.json'
+    api_id = "default"
+    if len(a) != 0:
+        api_id = a
+    api = ApiMapping(api_mapping_file)
+    api.load_mapping()
+    api_url = api.get_formed_url(api_id, city)
+    api.load_fields(api_id)
 
-    w = wdic["current"]["temp_c"]
-    w1 = wdic["current"]["temp_f"]
-    w2 = wdic["current"]["wind_mph"]
-    w3 = wdic["current"]["wind_kph"]
-    w4 = wdic["current"]["humidity"]
-    w5 = wdic["current"]["cloud"]
+    r = requests.get(api_url)
+    api_json = json.loads(r.text)
+    w = api.parse_fields(api_json)
 
     if x == 'r':
-        print(f"The current weather in {city} is {w} degrees Celsius.")
-        print(f"The current weather in {city} is {w1} degrees Fahrenheit.")
-        print(f"The current weather in {city} has {w2} mph wind speed.")
-        print(f"The current weather in {city} has {w3} kph wind speed.")
-        print(f"The current weather in {city} has {w4}% humidity.")
-        print(f"The current weather in {city} has {w5}% cloud coverage.")
+        print(f"The current weather in {city} is {w["temp"]} degrees Celsius.")
+        print(f"The current weather in {city} is {w["temp_f"]} degrees Fahrenheit.")
+        print(f"The current weather in {city} has {w["wind_mph"]} mph wind speed.")
+        print(f"The current weather in {city} has {w["wind_kph"]} kph wind speed.")
+        print(f"The current weather in {city} has {w["humidity"]}% humidity.")
+        print(f"The current weather in {city} has {w["cloudcover"]}% cloud coverage.")
     elif x == 'l':
-        os.system(f"say 'The current weather in {city} is {w} degrees Celsius.'")
-        os.system(f"say 'The current weather in {city} is {w1} degrees Fahrenheit.'")
-        os.system(f"say 'The current weather in {city} has {w2} mph wind speed.'")
-        os.system(f"say 'The current weather in {city} has {w3} kph wind speed.'")
-        os.system(f"say 'The current weather in {city} has {w4}% humidity.'")
-        os.system(f"say 'The current weather in {city} has {w5}% cloud coverage.'")
+        os.system(f"say 'The current weather in {city} is {w["temp"]} degrees Celsius.'")
+        os.system(f"say 'The current weather in {city} is {w["temp_f"]} degrees Fahrenheit.'")
+        os.system(f"say 'The current weather in {city} has {w["wind_mph"]} mph wind speed.'")
+        os.system(f"say 'The current weather in {city} has {w["wind_kph"]} kph wind speed.'")
+        os.system(f"say 'The current weather in {city} has {w["humidity"]}% humidity.'")
+        os.system(f"say 'The current weather in {city} has {w["coudcover"]}% cloud coverage.'")
     else:
         print("Please enter a valid option ('r' to read or 'l' to listen).")
 
 # Example usage
 city= input("Enter the name of the city:\n")
 x = input("Enter 'r' to read the weather information or 'l' to listen:\n")
-weather_info(city, x)
+a = input("Enter/Return for the default api or the API id: \n")
+weather_info(city, x, a)
 
+# Example use cases
+# 'PHL' / 'r' or 'l' / 'Enter' or 'default'
+# 'Philadelphia' / 'r' or 'l' / 'visualcrossing.com'
+# 'PHL' / 'r' or 'l' / 'weatherstack.com'


### PR DESCRIPTION
…g class to handle multiple API vendors.

api_mapping.json includes the mapping for the original version of the code, and two new sample mappings for additional apis. api_mapping.py includes the classes FieldClass and ApiMapping. ApiMapping class contains all methods to build a fully formed request url from json configurations. Fields may be added later, via the config.

Along with the docstring comments, I attempted to make my commit remarks self-explanatory.
In essence, for whatever API you want to call, the field mappings are kept in a mapping json file. I changed the CLI's default option to the original for weatherapi.com. I also added weatherstack.com and visualcrossing.com. 
While I investigated four others, they all seems to return data in the format of these. The original was an outlier returning both imperial and metric which is not available in one api call for the other sites, so I handled that by adding conversion methods for any API definition that doesn't include the fields. (exa temp_f, and wind_mph) Those are calculated if missing.
I am happy to make additional changes, but as a starting point, this seems like a workable base. I endeavored to not bloat the single python file and encapsulate the functionality into logical bits which can be hidden from the weather2.py "driver" file.